### PR TITLE
PR: Add recall plugin — save and switch to windows by name

### DIFF
--- a/core/command_client/README.md
+++ b/core/command_client/README.md
@@ -2,6 +2,18 @@
 
 This directory contains the client code for communicating with the [VSCode command server](https://marketplace.visualstudio.com/items?itemName=pokey.command-server).
 
+## Hotkey conflicts
+
+Common reason for the `Exception: Timed out waiting for response` error in the Talon log.
+
+The command client sends key presses that the command server listens for as a signal to start processing the request. If you have another application or IDE extension using the same hotkey a conflict will occur. The command server will never process the request and the client will time out.
+
+The hotkeys to look for are:
+
+- [Windows & non-VSCode Linux: `ctrl-shift-f17`](https://github.com/talonhub/community/blob/358d327b96891f628bd84728831a3fb544a27a15/core/command_client/command_client.py#L129)
+- [Mac: `cmd-shift-f17`](https://github.com/talonhub/community/blob/358d327b96891f628bd84728831a3fb544a27a15/core/command_client/command_client.py#L148)
+- [VSCode Linux: `ctrl-shift-alt-p`](https://github.com/talonhub/community/blob/358d327b96891f628bd84728831a3fb544a27a15/apps/vscode/vscode_command_client.py#L107)
+
 ## Contributing
 
 The source of truth is in https://github.com/talonhub/community/tree/main/core/command_client, but the code is also maintained as a subtree at https://github.com/cursorless-dev/talon-command-client.

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -1,5 +1,5 @@
 from inspect import signature
-from typing import Callable
+from typing import Callable, Union
 
 from talon import Module, actions, settings
 
@@ -168,7 +168,9 @@ compound_actions = {
 
 @mod.action_class
 class Actions:
-    def edit_command(action: EditAction | str, modifier: EditModifier | str):
+    def edit_command(
+        action: Union[EditAction, str], modifier: Union[EditModifier, str]
+    ):
         """Perform edit command with associated modifier.
         Action and modifier can be dataclasses (formed from utterances via
         capture) or str, for use in scripts. Strings should match the action or

--- a/core/edit/edit_command_actions.py
+++ b/core/edit/edit_command_actions.py
@@ -49,7 +49,10 @@ EditAction = Union[
 ]
 
 mod = Module()
-mod.list("edit_action", desc="Actions for the edit command")
+mod.list(
+    "edit_action",
+    desc="Edit command actions. Follow an action by an edit modifier to perform the action on the modifier's target.",
+)
 
 
 @mod.capture(rule="{user.edit_action}")

--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -8,7 +8,7 @@ mod = Module()
 mod.list("edit_modifier", desc="Modifiers for the edit command")
 mod.list(
     "edit_modifier_repeatable",
-    desc="Modifiers for the edit command that are repeatable",
+    desc="Edit modifiers that are repeatable. Say a number before the modifier to repeat the action that many times.",
 )
 
 

--- a/core/help/help.talon
+++ b/core/help/help.talon
@@ -21,6 +21,9 @@ help keywords: user.help_list("user.code_keyword")
 help keywords unprefixed: user.help_list("user.code_keyword_unprefixed")
 help common methods: user.help_list("user.code_common_method")
 help pairs: user.help_list("user.delimiter_pair")
+help edit actions: user.help_list("user.edit_action")
+help edit modifiers: user.help_list("user.edit_modifier")
+help edit repeatable modifiers: user.help_list("user.edit_modifier_repeatable")
 help customize: user.help_list("user.edit_text_file")
 
 (help formatters | help format | format help):

--- a/core/help/help.talon
+++ b/core/help/help.talon
@@ -21,6 +21,7 @@ help keywords: user.help_list("user.code_keyword")
 help keywords unprefixed: user.help_list("user.code_keyword_unprefixed")
 help common methods: user.help_list("user.code_common_method")
 help pairs: user.help_list("user.delimiter_pair")
+help customize: user.help_list("user.edit_text_file")
 
 (help formatters | help format | format help):
     user.help_formatters(user.get_formatters_words(), false)

--- a/core/snippets/snippets/commentBlock.snippet
+++ b/core/snippets/snippets/commentBlock.snippet
@@ -5,7 +5,7 @@ insertionScope: statement
 $0.insertionFormatter: CAPITALIZE_FIRST_WORD
 ---
 
-language: c | cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact | php | scala | kotlin
+language: c | cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact | php | scala | kotlin | go
 -
 /* $0 */
 ---

--- a/core/snippets/snippets/forLoopReverseStatement.snippet
+++ b/core/snippets/snippets/forLoopReverseStatement.snippet
@@ -1,0 +1,11 @@
+name: forLoopReverseStatement
+phrase: for reverse
+insertionScope: statement
+---
+
+language: go
+-
+for i := $1; i >= 0; i-- {
+    $0
+}
+---

--- a/core/snippets/snippets/formatString.snippet
+++ b/core/snippets/snippets/formatString.snippet
@@ -31,3 +31,8 @@ language: r
 -
 ${1:glue::}glue("$0")
 ---
+
+language: go
+-
+fmt.Sprintf("$0", $1)
+---

--- a/core/snippets/snippets/functionCall.snippet
+++ b/core/snippets/snippets/functionCall.snippet
@@ -5,7 +5,7 @@ insertionScope: statement
 $0.wrapperPhrase: call
 ---
 
-language: c | cpp | csharp | python | talon | java | javascript | typescript | javascriptreact | typescriptreact | css | scss | sql | r
+language: c | cpp | csharp | python | talon | java | javascript | typescript | javascriptreact | typescriptreact | css | scss | sql | r | go
 -
 $1($0)
 ---

--- a/core/snippets/snippets/functionDeclaration.snippet
+++ b/core/snippets/snippets/functionDeclaration.snippet
@@ -33,6 +33,7 @@ def $1($2):
 ---
 
 language: rust
+
 $1.insertionFormatter: SNAKE_CASE
 -
 fn $1($2) {
@@ -70,6 +71,15 @@ language: r
 $1.insertionFormatter: SNAKE_CASE
 -
 $1 <- function($2){
+    $0
+}
+---
+
+language: go
+
+$1.insertionFormatter: PRIVATE_CAMEL_CASE
+-
+func $1($2) {
     $0
 }
 ---

--- a/core/snippets/snippets/goToStatement.snippet
+++ b/core/snippets/snippets/goToStatement.snippet
@@ -8,7 +8,7 @@ language: c | cpp | csharp | php
 goto $0;
 ---
 
-language: lua
+language: lua | go
 -
 goto $0
 ---

--- a/core/snippets/snippets/infiniteLoopStatement.snippet
+++ b/core/snippets/snippets/infiniteLoopStatement.snippet
@@ -9,3 +9,10 @@ loop {
     $0
 }
 ---
+
+language: go
+-
+for {
+    $0
+}
+---

--- a/core/snippets/snippets/interfaceDeclaration.snippet
+++ b/core/snippets/snippets/interfaceDeclaration.snippet
@@ -1,0 +1,22 @@
+name: interfaceDeclaration
+phrase: interface
+insertionScope: statement
+---
+
+language: typescript | typescriptreact
+
+$1.insertionFormatter: PUBLIC_CAMEL_CASE
+-
+interface $1 {
+    $0
+}
+---
+
+language: go
+
+$1.insertionFormatter: PUBLIC_CAMEL_CASE
+-
+type $1 interface {
+    $0
+}
+---

--- a/core/snippets/snippets/item.snippet
+++ b/core/snippets/snippets/item.snippet
@@ -3,7 +3,7 @@ phrase: item
 insertionScope: collectionItem
 ---
 
-language: javascript | typescript | javascriptreact | typescriptreact
+language: javascript | typescript | javascriptreact | typescriptreact | go
 -
 $1: $0,
 ---

--- a/core/snippets/snippets/lambdaExpression.snippet
+++ b/core/snippets/snippets/lambdaExpression.snippet
@@ -29,10 +29,16 @@ language: r
 function($1){ $0 }
 ---
 
-
 language: cpp
 -
 [$1]($2) {
+    $0
+}
+---
+
+language: go
+-
+func($1) $2 {
     $0
 }
 ---

--- a/core/snippets/snippets/methodDeclaration.snippet
+++ b/core/snippets/snippets/methodDeclaration.snippet
@@ -11,3 +11,12 @@ $1($2) {
     $0
 }
 ---
+
+language: go
+
+$1.insertionFormatter: PUBLIC_CAMEL_CASE
+-
+func ($2) $1($3) $4{
+    $0
+}
+---

--- a/core/snippets/snippets/newInstance.snippet
+++ b/core/snippets/snippets/newInstance.snippet
@@ -11,3 +11,8 @@ language: python
 -
 $1($0)
 ---
+
+language: go
+-
+$1{$0}
+---

--- a/core/snippets/snippets/printStatement.snippet
+++ b/core/snippets/snippets/printStatement.snippet
@@ -34,3 +34,8 @@ language: rust
 -
 println!($0);
 ---
+
+language: go
+-
+fmt.Println($0)
+---

--- a/core/snippets/snippets/structDeclaration.snippet
+++ b/core/snippets/snippets/structDeclaration.snippet
@@ -1,5 +1,6 @@
 name: structDeclaration
 phrase: struct
+
 $1.insertionFormatter: PUBLIC_CAMEL_CASE
 ---
 
@@ -17,3 +18,12 @@ insertionScope: statement
 struct $1 {
     $0
 };
+---
+
+language: go
+insertionScope: statement
+-
+type $1 struct {
+    $0
+}
+---

--- a/core/snippets/snippets/switchStatement.snippet
+++ b/core/snippets/snippets/switchStatement.snippet
@@ -47,7 +47,7 @@ $1 match {
 language: go
 -
 switch $1 {
-    $0
+$0
 }
 ---
 

--- a/core/snippets/snippets/typescript.snippet
+++ b/core/snippets/snippets/typescript.snippet
@@ -1,13 +1,2 @@
 language: typescript | typescriptreact
 ---
-
-name: interfaceDeclaration
-phrase: interface
-insertionScope: statement
-
-$1.insertionFormatter: PUBLIC_CAMEL_CASE
--
-interface $1 {
-    $0
-}
----

--- a/lang/c/c_type_bit_width.talon-list
+++ b/lang/c/c_type_bit_width.talon-list
@@ -1,7 +1,9 @@
 list: user.c_type_bit_width
 code.language: c
 code.language: cpp
+code.language: go
 -
+
 eight: 8
 sixteen: 16
 thirty two: 32

--- a/lang/c/stdint_signed.talon-list
+++ b/lang/c/stdint_signed.talon-list
@@ -1,7 +1,9 @@
 list: user.stdint_signed
 code.language: c
 code.language: cpp
+code.language: go
 -
+
 signed: ""
 unsigned: u
 you: u

--- a/lang/go/code_keyword.talon-list
+++ b/lang/go/code_keyword.talon-list
@@ -1,0 +1,23 @@
+list: user.code_keyword
+code.language: go
+-
+
+break: "break"
+continue: "continue"
+struct: "struct"
+type: "type"
+return: "return"
+package: "package"
+import: "import"
+null: "nil"
+nil: "nil"
+true: "true"
+false: "false"
+defer: "defer"
+go: "go"
+if: "if"
+else: "else"
+switch: "switch"
+select: "select"
+const: "const"
+var: "var "

--- a/lang/go/code_type.talon-list
+++ b/lang/go/code_type.talon-list
@@ -1,0 +1,13 @@
+list: user.code_type
+code.language: go
+-
+
+boolean: "bool"
+int: "int"
+you int: "uint"
+you int pointer: "uintptr"
+string: "string"
+byte: "byte"
+rune: "rune"
+channel: "chan "
+error: "error"

--- a/lang/go/complex_type_bit_width.talon-list
+++ b/lang/go/complex_type_bit_width.talon-list
@@ -1,0 +1,8 @@
+list: user.complex_type_bit_width
+code.language: go
+-
+
+sixty four: 64
+one hundred and twenty eight: 128
+one twenty eight: 128
+one two eight: 128

--- a/lang/go/float_type_bit_width.talon-list
+++ b/lang/go/float_type_bit_width.talon-list
@@ -1,0 +1,6 @@
+list: user.float_type_bit_width
+code.language: go
+-
+
+thirty two: 32
+sixty four: 64

--- a/lang/go/go.talon
+++ b/lang/go/go.talon
@@ -16,6 +16,7 @@ tag(): user.code_operators_bitwise
 tag(): user.code_operators_lambda
 tag(): user.code_operators_math
 tag(): user.code_operators_pointer
+tag(): user.code_keywords
 
 settings():
     user.code_private_function_formatter = "PRIVATE_CAMEL_CASE"

--- a/plugin/mode_indicator/mode_indicator.py
+++ b/plugin/mode_indicator/mode_indicator.py
@@ -50,6 +50,7 @@ mod.setting(
 mod.setting("mode_indicator_color_text", type=str)
 mod.setting("mode_indicator_color_mute", type=str)
 mod.setting("mode_indicator_color_sleep", type=str)
+mod.setting("mode_indicator_color_deep_sleep", type=str)
 mod.setting("mode_indicator_color_dictation", type=str)
 mod.setting("mode_indicator_color_mixed", type=str)
 mod.setting("mode_indicator_color_command", type=str)
@@ -64,6 +65,7 @@ setting_paths = {
     "user.mode_indicator_color_gradient",
     "user.mode_indicator_color_mute",
     "user.mode_indicator_color_sleep",
+    "mode_indicator_color_deep_sleep",
     "user.mode_indicator_color_dictation",
     "user.mode_indicator_color_mixed",
     "user.mode_indicator_color_command",
@@ -75,6 +77,8 @@ def get_mode_color() -> str:
     if current_microphone == "None":
         return settings.get("user.mode_indicator_color_mute")
     if current_mode == "sleep":
+        if "user.deep_sleep" in scope.get("tag"):
+            return settings.get("user.mode_indicator_color_deep_sleep")
         return settings.get("user.mode_indicator_color_sleep")
     elif current_mode == "dictation":
         return settings.get("user.mode_indicator_color_dictation")

--- a/plugin/mode_indicator/mode_indicator.talon
+++ b/plugin/mode_indicator/mode_indicator.talon
@@ -19,6 +19,8 @@ settings():
     user.mode_indicator_color_mute = "000000"
     # Grey color for sleep mode
     user.mode_indicator_color_sleep = "808080"
+    # Red color for deep sleep
+    user.mode_indicator_color_deep_sleep = "FF0000"
     # Gold color for dictation mode
     user.mode_indicator_color_dictation = "ffd700"
     # MediumSeaGreen color for mixed mode

--- a/plugin/recall/recall.py
+++ b/plugin/recall/recall.py
@@ -1,0 +1,163 @@
+"""
+Recall - Save and recall specific windows by name
+
+Allows you to save specific windows and bring them back later by name,
+solving the problem where "focus chrome" brings any Chrome window instead
+of the specific one you care about.
+
+Features:
+- Save the focused window with a name: "recall assign edgar" or "recall save edgar"
+- Switch to it by just saying the name: "edgar"
+- Dictate into a named window: "edgar hello world"
+- See all named windows: "recall list" (shows overlay labels for 5 seconds)
+- Forget a named window: "recall forget edgar"
+"""
+
+import json
+from pathlib import Path
+from talon import Module, Context, actions, app, ui
+from . import recall_overlay
+
+mod = Module()
+ctx = Context()
+
+# Storage file path
+STORAGE_FILE = Path(__file__).parent / "saved_windows.json"
+
+# In-memory storage: {name: {id: int, app: str, title: str}}
+saved_windows = {}
+
+mod.list("saved_window_names", desc="Names of saved windows for recall")
+
+
+@mod.capture(rule="{self.saved_window_names}")
+def saved_window_names(m) -> str:
+    """Returns a single saved window name"""
+    return m.saved_window_names
+
+
+def load_saved_windows():
+    """Load saved windows from JSON file"""
+    global saved_windows
+    if STORAGE_FILE.exists():
+        try:
+            with open(STORAGE_FILE, "r") as f:
+                saved_windows = json.load(f)
+            update_window_list()
+        except Exception as e:
+            print(f"[recall] Error loading saved windows: {e}")
+            saved_windows = {}
+
+
+def save_to_disk():
+    """Persist saved windows to JSON file"""
+    try:
+        with open(STORAGE_FILE, "w") as f:
+            json.dump(saved_windows, f, indent=2)
+    except Exception as e:
+        print(f"[recall] Error saving to disk: {e}")
+
+
+def update_window_list():
+    """Update the dynamic list of saved window names for voice commands"""
+    if saved_windows:
+        window_names = list(saved_windows.keys())
+        spoken_forms = actions.user.create_spoken_forms_from_list(
+            window_names,
+            generate_subsequences=True
+        )
+        ctx.lists["self.saved_window_names"] = spoken_forms
+    else:
+        ctx.lists["self.saved_window_names"] = {}
+
+
+def find_window_by_id(window_id: int) -> ui.Window:
+    """Find a window by its ID across all apps"""
+    for a in ui.apps(background=False):
+        for window in a.windows():
+            if window.id == window_id:
+                return window
+    return None
+
+
+def cleanup_closed_windows(closed_window: ui.Window):
+    """Remove saved windows that have been closed"""
+    global saved_windows
+
+    removed = []
+    for name, info in list(saved_windows.items()):
+        if info["id"] == closed_window.id:
+            del saved_windows[name]
+            removed.append(name)
+
+    if removed:
+        save_to_disk()
+        update_window_list()
+
+
+@mod.action_class
+class Actions:
+    def save_window(name: str):
+        """Save the currently focused window with the given name"""
+        global saved_windows
+
+        window = ui.active_window()
+        saved_windows[name] = {
+            "id": window.id,
+            "app": window.app.name,
+            "title": window.title
+        }
+
+        save_to_disk()
+        update_window_list()
+
+    def recall_window(name: str):
+        """Focus the saved window with the given name"""
+        if name not in saved_windows:
+            return
+
+        info = saved_windows[name]
+        window = find_window_by_id(info["id"])
+
+        if window is None:
+            recall_overlay.show_overlay()
+            return
+
+        actions.user.switcher_focus_window(window)
+
+    def forget_window(name: str):
+        """Remove a saved window by name"""
+        global saved_windows
+
+        if name not in saved_windows:
+            return
+
+        del saved_windows[name]
+        save_to_disk()
+        update_window_list()
+
+    def forget_all_windows():
+        """Clear all saved windows"""
+        global saved_windows
+
+        saved_windows = {}
+        save_to_disk()
+        update_window_list()
+
+    def dictate_to_window(name: str, text: str):
+        """Focus a saved window and type dictated text into it"""
+        actions.user.recall_window(name)
+        actions.user.dictation_insert(text)
+
+    def list_saved_windows():
+        """Show window name labels on each saved window for 5 seconds"""
+        recall_overlay.show_overlay()
+
+
+def on_ready():
+    """Initialize on Talon startup"""
+    load_saved_windows()
+    ui.register("win_close", cleanup_closed_windows)
+
+
+app.register("ready", on_ready)

--- a/plugin/recall/recall.talon
+++ b/plugin/recall/recall.talon
@@ -1,0 +1,26 @@
+# Voice commands for the window recall system
+#
+# Save a window:     "recall assign edgar" or "recall save edgar"
+# Switch to it:      "edgar"
+# Dictate into it:   "edgar hello world"
+# List all:          "recall list"
+# Forget one:        "recall forget edgar"
+# Forget all:        "recall forget all"
+
+(recall save | save recall | recall assign) <user.text>:
+    user.save_window(text)
+
+<user.saved_window_names>:
+    user.recall_window(saved_window_names)
+
+(recall forget | forget recall) <user.saved_window_names>:
+    user.forget_window(saved_window_names)
+
+(recall list | list recalls):
+    user.list_saved_windows()
+
+recall forget all:
+    user.forget_all_windows()
+
+<user.saved_window_names> <user.raw_prose>:
+    user.dictate_to_window(saved_window_names, raw_prose)

--- a/plugin/recall/recall_overlay.py
+++ b/plugin/recall/recall_overlay.py
@@ -1,0 +1,131 @@
+"""
+Recall Overlay - Temporary window name labels
+
+Shows a name tag on each saved window for 5 seconds,
+triggered by "recall list" / "list recalls".
+Windows that can't be found are shown in red at the top of the screen.
+"""
+
+from talon import cron, ui
+from talon.canvas import Canvas
+from talon.screen import Screen
+from talon.skia.canvas import Canvas as SkiaCanvas
+from talon.ui import Rect
+
+canvas: Canvas = None
+_hide_job = None
+
+# Padding and styling constants
+PAD_X = 20
+PAD_Y = 12
+FONT_SIZE = 48
+SHOW_DURATION = "5s"
+MISSING_GAP = 10  # vertical gap between stacked missing-window labels
+
+
+def _get_saved_windows():
+    """Import saved_windows lazily to avoid circular imports."""
+    from .recall import saved_windows, find_window_by_id
+    return saved_windows, find_window_by_id
+
+
+def on_draw(c: SkiaCanvas):
+    saved_windows, find_window_by_id = _get_saved_windows()
+    screen = ui.main_screen()
+
+    missing_y_offset = 80  # start below top bar area
+
+    for name, info in saved_windows.items():
+        window = find_window_by_id(info["id"])
+
+        c.paint.textsize = FONT_SIZE
+        text_rect = c.paint.measure_text(name)[1]
+        text_w = text_rect.width
+        text_h = text_rect.height
+
+        pill_w = text_w + PAD_X * 2
+        pill_h = text_h + PAD_Y * 2
+
+        if window is not None:
+            rect = window.rect
+            if rect.width <= 0 or rect.height <= 0:
+                continue
+
+            # Center label on window
+            center_x = rect.x + rect.width / 2
+            center_y = rect.y + rect.height / 2
+            pill_x = center_x - pill_w / 2
+            pill_y = center_y - pill_h / 2
+            text_x = center_x - text_w / 2
+            text_y = center_y + text_h / 2
+            bg_color = "000000bb"
+            text_color = "ffffffff"
+        else:
+            # Show missing windows at top-center of screen in red
+            display = f"{name} (not found)"
+            c.paint.textsize = FONT_SIZE
+            text_rect = c.paint.measure_text(display)[1]
+            text_w = text_rect.width
+            text_h = text_rect.height
+            pill_w = text_w + PAD_X * 2
+            pill_h = text_h + PAD_Y * 2
+
+            center_x = screen.rect.x + screen.rect.width / 2
+            pill_x = center_x - pill_w / 2
+            pill_y = missing_y_offset
+            text_x = center_x - text_w / 2
+            text_y = missing_y_offset + PAD_Y + text_h
+            bg_color = "aa0000cc"
+            text_color = "ffffffff"
+            name = display
+            missing_y_offset += pill_h + MISSING_GAP
+
+        # Draw background
+        c.paint.style = c.paint.Style.FILL
+        c.paint.color = bg_color
+        c.draw_rect(Rect(pill_x, pill_y, pill_w, pill_h))
+
+        # Draw text
+        c.paint.style = c.paint.Style.FILL
+        c.paint.color = text_color
+        c.draw_text(name, text_x, text_y)
+
+
+def show_overlay():
+    """Show labels on all saved windows for 5 seconds."""
+    global canvas, _hide_job
+
+    # Cancel any pending hide
+    if _hide_job:
+        cron.cancel(_hide_job)
+        _hide_job = None
+
+    # Tear down existing canvas before creating new one
+    if canvas:
+        canvas.unregister("draw", on_draw)
+        canvas.close()
+        canvas = None
+
+    saved_windows, _ = _get_saved_windows()
+    if not saved_windows:
+        return
+
+    screen: Screen = ui.main_screen()
+    canvas = Canvas.from_screen(screen)
+    canvas.register("draw", on_draw)
+    canvas.freeze()
+
+    # Auto-hide after duration
+    _hide_job = cron.after(SHOW_DURATION, hide_overlay)
+
+
+def hide_overlay():
+    """Hide and destroy the overlay canvas."""
+    global canvas, _hide_job
+    if _hide_job:
+        cron.cancel(_hide_job)
+        _hide_job = None
+    if canvas:
+        canvas.unregister("draw", on_draw)
+        canvas.close()
+        canvas = None


### PR DESCRIPTION
I work in mixed mode and frequently need to dictate into specific windows — chat apps, terminals, editors — without manually switching focus first. This plugin lets me assign short, distinct names to windows (e.g. "edgar", "velma") and then speak naturally: saying "edgar hey can you check on that" switches focus to the edgar window and types the rest. The name doubles as both a focus command and a dictation prefix, so there's no interruption in the flow of speech.

The app switcher lets you focus apps by name, but if you have multiple windows of the same app (e.g. three Chrome windows), there's no way to target a specific one.

Commands:
- `recall (assign | save) <name>` — save the focused window
- `<name>` — switch to it
- `<name> <prose>` — dictate into it
- `recall list` — flash overlay labels on all named windows (5s)
- `recall forget <name>` / `recall forget all` — remove

Window names persist to disk across Talon restarts. Missing windows show in red on the overlay.